### PR TITLE
Upgrade tailwind to V4 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ You can configure TailwindCSS in your `gleam.toml` by adding a `tailwind` table:
 
 ```toml
 [tailwind]
-version = "3.4.1" # optional
+version = "4.0.8" # optional
 args = [
-    "--config=tailwind.config.js",
     "--input=./src/css/app.css",
     "--output=./priv/css/app.css"
 ]
-path = "/path/to/tailwindcli" # optional
+path = "/path/to/tailwindcss" # optional
 ```
 
 This lets you define the arguments being run.
@@ -42,14 +41,13 @@ Optionally define a specific TailwindCSS version or the direct path to the Tailw
 gleam run -m tailwind/install
 ```
 
-This downloads the Tailwind CLI to `./build/bin/tailwind-cli` and generates the `tailwind.config.js` in the root of the project.
+This downloads the Tailwind CLI to `./build/bin/tailwindcss` and generates the `input.css` in the root of the project.
 
 ### Import Tailwind in your CSS
 
 ```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
 ```
 
 ### Run TailwindCSS
@@ -76,7 +74,7 @@ gleam add glailglind
 
 ```toml
 [tailwind]
-version = "3.3.5"
+version = "4.0.8"
 ```
 
 ### Install TailwindCSS
@@ -88,9 +86,7 @@ gleam run -m tailwind/install
 ### Import Tailwind in your CSS
 
 ```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 ```
 
 ### Update build script
@@ -134,7 +130,7 @@ pub fn main() {
     |> result.map_error(fn(e) { string.inspect(e) })
     |> result.try(fn(_) {
       [
-        "--config=tailwind.config.js", "--input=./assets/css/app.css",
+        "--input=./assets/css/app.css",
         "--output=./priv/css/app.css",
       ]
       |> tailwind.run()

--- a/gleam.toml
+++ b/gleam.toml
@@ -19,9 +19,5 @@ gleam_erlang = ">= 0.34.0 and < 2.0.0"
 gleeunit = ">= 1.3.0 and < 2.0.0"
 
 [tailwind]
-version = "3.4.1"
-args = [
-    "--config=tailwind.config.js",
-    "--input=./test/input.css",
-    "--output=./build/css/output.css",
-]
+version = "4.0.8"
+args = ["-i=./test/input.css", "-o=./build/css/output.css"]

--- a/gleam.toml
+++ b/gleam.toml
@@ -7,21 +7,21 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "okkdev", repo = "glailglind" }
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-gleam_httpc = ">= 2.1.0 and < 3.0.0"
-gleam_http = ">= 3.5.0 and < 4.0.0"
-simplifile = ">= 2.0.0 and < 3.0.0"
-tom = ">= 1.0.0 and < 2.0.0"
-shellout = ">= 1.0.0 and < 2.0.0"
-gleam_erlang = ">= 0.24.0 and < 2.0.0"
+gleam_stdlib = ">= 0.55.0 and < 2.0.0"
+gleam_httpc = ">= 4.1.0 and < 5.0.0"
+gleam_http = ">= 3.7.2 and < 4.0.0"
+simplifile = ">= 2.2.0 and < 3.0.0"
+tom = ">= 1.1.1 and < 2.0.0"
+shellout = ">= 1.6.0 and < 2.0.0"
+gleam_erlang = ">= 0.34.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.3.0 and < 2.0.0"
 
 [tailwind]
 version = "3.4.1"
 args = [
-  "--config=tailwind.config.js",
-  "--input=./test/input.css",
-  "--output=./build/css/output.css",
+    "--config=tailwind.config.js",
+    "--input=./test/input.css",
+    "--output=./build/css/output.css",
 ]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "glailglind"
-version = "1.1.3"
+version = "2.0.0"
 gleam = ">= 0.34.0"
 
 description = "Gleam modules and functions for installing and invoking TailwindCSS"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,23 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
-  { name = "gleam_httpc", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "CF76C71002DEECF6DC5D9CA83D962728FAE166B57926BE442D827004D3C7DF1B" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
+  { name = "gleam_httpc", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "1A38507AF26CACA145248733688703EADCB734EA971D4E34FB97B7613DECF132" },
+  { name = "gleam_stdlib", version = "0.55.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "32D8F4AE03771516950047813A9E359249BD9FBA5C33463FDB7B953D6F8E896B" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
   { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
-  { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
-  { name = "tom", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "A5364613E3DBF77F38EFF81DA9F99324086D029EC2B2D44348762FBE38602311" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
+  { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.24.0 and < 2.0.0" }
-gleam_http = { version = ">= 3.5.0 and < 4.0.0" }
-gleam_httpc = { version = ">= 2.1.0 and < 3.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
-gleeunit = { version = "~> 1.0" }
-shellout = { version = ">= 1.0.0 and < 2.0.0" }
-simplifile = { version = ">= 2.0.0 and < 3.0.0" }
-tom = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_http = { version = ">= 3.7.2 and < 4.0.0" }
+gleam_httpc = { version = ">= 4.1.0 and < 5.0.0" }
+gleam_stdlib = { version = ">= 0.55.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.3.0 and < 2.0.0" }
+shellout = { version = ">= 1.6.0 and < 2.0.0" }
+simplifile = { version = ">= 2.2.0 and < 3.0.0" }
+tom = { version = ">= 1.1.1 and < 2.0.0" }

--- a/src/tailwind.gleam
+++ b/src/tailwind.gleam
@@ -235,12 +235,19 @@ fn download_bin(path: String) -> Result(Nil, String) {
 
 @target(erlang)
 fn download_bin(path: String) -> Result(Nil, String) {
-  request.new()
-  |> request.set_method(Get)
-  |> request.set_host("github.com")
-  |> request.set_path(path)
-  |> request.map(bit_array.from_string)
-  |> httpc.send_bits()
+  let request =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("github.com")
+    |> request.set_path(path)
+    |> request.map(bit_array.from_string)
+
+  let response =
+    httpc.configure()
+    |> httpc.follow_redirects(True)
+    |> httpc.dispatch_bits(request)
+
+  response
   |> result.map_error(fn(err) {
     "Error: Couldn't download tailwind. Reason: " <> string.inspect(err)
   })

--- a/test/glailglind_test.gleam
+++ b/test/glailglind_test.gleam
@@ -14,7 +14,7 @@ pub fn main() {
 @target(erlang)
 pub fn install_test_() {
   let assert Ok(timeout) = atom.from_string("timeout")
-  #(timeout, 30.0, [fn() { install_test_body() }])
+  #(timeout, 60.0, [fn() { install_test_body() }])
 }
 
 @target(javascript)

--- a/test/glailglind_test.gleam
+++ b/test/glailglind_test.gleam
@@ -26,17 +26,16 @@ fn install_test_body() {
   tailwind.install()
   |> should.be_ok()
 
-  simplifile.is_file("./build/bin/tailwindcss-cli")
+  simplifile.is_file("./build/bin/tailwindcss")
   |> result.unwrap(False)
   |> should.be_true()
 }
 
 // This test depends on the install test so it will fail if its run first
 pub fn run_test() {
-  [
-    "--config=tailwind.config.js", "--input=./test/input.css",
-    "--output=./build/css/output.css",
-  ]
+  install_test_()
+
+  ["--input=./test/input.css", "--output=./build/css/output.css"]
   |> tailwind.run()
   |> should.be_ok()
 

--- a/test/input.css
+++ b/test/input.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";


### PR DESCRIPTION
This PR upgrades tailwind to V4 and generates a basic `input.css` according to the new configuration format. It also bumps sub dependencies up.

Technically it's a breaking change as without some manual editing of generated files, the default use and expect the v4 config format.