### PR TITLE
Up gleam_http to < 5.0.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,7 +9,7 @@ repository = { type = "github", user = "okkdev", repo = "glailglind" }
 [dependencies]
 gleam_stdlib = ">= 0.55.0 and < 2.0.0"
 gleam_httpc = ">= 4.1.0 and < 5.0.0"
-gleam_http = ">= 3.7.2 and < 4.0.0"
+gleam_http = ">= 3.7.2 and < 5.0.0"
 simplifile = ">= 2.2.0 and < 3.0.0"
 tom = ">= 1.1.1 and < 2.0.0"
 shellout = ">= 1.6.0 and < 2.0.0"


### PR DESCRIPTION
I'm currently working with lustre/mist/wisp on a new app and mist now uses >4.0.0 gleam_http, so to resolve this I've upped this version. Seems to be ok for me so far