### PR TITLE
Update dependencies. Use `atom.get` instead of `atom.from_string`

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,16 +7,16 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "okkdev", repo = "glailglind" }
 
 [dependencies]
-gleam_stdlib = ">= 0.55.0 and < 2.0.0"
-gleam_httpc = ">= 4.1.0 and < 5.0.0"
-gleam_http = ">= 3.7.2 and < 5.0.0"
-simplifile = ">= 2.2.0 and < 3.0.0"
-tom = ">= 1.1.1 and < 2.0.0"
-shellout = ">= 1.6.0 and < 2.0.0"
-gleam_erlang = ">= 0.34.0 and < 2.0.0"
+gleam_stdlib = ">= 0.61.0 and < 1.0.0"
+gleam_httpc = ">= 4.2.1 and < 5.0.0"
+gleam_http = ">= 4.1.0 and < 5.0.0"
+simplifile = ">= 2.3.0 and < 3.0.0"
+tom = ">= 2.0.0 and < 3.0.0"
+shellout = ">= 1.7.0 and < 2.0.0"
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = ">= 1.3.0 and < 2.0.0"
+gleeunit = ">= 1.6.0 and < 2.0.0"
 
 [tailwind]
 version = "4.0.8"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,23 +2,24 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
-  { name = "gleam_httpc", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "1A38507AF26CACA145248733688703EADCB734EA971D4E34FB97B7613DECF132" },
-  { name = "gleam_stdlib", version = "0.55.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "32D8F4AE03771516950047813A9E359249BD9FBA5C33463FDB7B953D6F8E896B" },
-  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
-  { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
-  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
-  { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_http", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "DB25DFC8530B64B77105405B80686541A0D96F7E2D83D807D6B2155FB9A8B1B8" },
+  { name = "gleam_httpc", version = "4.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "224BF35B2091502921D1623F35E6FA52815B75D99D18AEFB9DAEA0B8AEADD7A1" },
+  { name = "gleam_stdlib", version = "0.61.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3DC407D6EDA98FCE089150C11F3AD892B6F4C3CA77C87A97BAE8D5AB5E41F331" },
+  { name = "gleam_time", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "F9AB61CE910F3071B136E1C8E214A46C406734F710D3AF75C99B00DA785902A2" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
+  { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
+  { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
+  { name = "tom", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "74D0C5A3761F7A7D06994755D4D5AD854122EF8E9F9F76A3E7547606D8C77091" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.34.0 and < 2.0.0" }
-gleam_http = { version = ">= 3.7.2 and < 5.0.0" }
-gleam_httpc = { version = ">= 4.1.0 and < 5.0.0" }
-gleam_stdlib = { version = ">= 0.55.0 and < 2.0.0" }
-gleeunit = { version = ">= 1.3.0 and < 2.0.0" }
-shellout = { version = ">= 1.6.0 and < 2.0.0" }
-simplifile = { version = ">= 2.2.0 and < 3.0.0" }
-tom = { version = ">= 1.1.1 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_http = { version = ">= 4.1.0 and < 5.0.0" }
+gleam_httpc = { version = ">= 4.2.1 and < 5.0.0" }
+gleam_stdlib = { version = ">= 0.61.0 and < 1.0.0" }
+gleeunit = { version = ">= 1.6.0 and < 2.0.0" }
+shellout = { version = ">= 1.7.0 and < 2.0.0" }
+simplifile = { version = ">= 2.3.0 and < 3.0.0" }
+tom = { version = ">= 2.0.0 and < 3.0.0" }

--- a/test/glailglind_test.gleam
+++ b/test/glailglind_test.gleam
@@ -12,7 +12,7 @@ pub fn main() {
 
 @target(erlang)
 pub fn install_erl_test_() {
-  let assert Ok(timeout) = atom.from_string("timeout")
+  let assert Ok(timeout) = atom.get("timeout")
   #(timeout, 60.0, [install_test_body])
 }
 


### PR DESCRIPTION
Just update dependencies to make sure there are no transitive dependency issues